### PR TITLE
Add Literal.club → StoryGraph export CLI script

### DIFF
--- a/scripts/literal-to-storygraph.py
+++ b/scripts/literal-to-storygraph.py
@@ -13,7 +13,10 @@ Usage:
   # Or use an existing token (valid ~6 months)
   LITERAL_TOKEN='...' python3 literal-to-storygraph.py --fetch -o storygraph-import.csv
 
-  # Convert a CSV you downloaded from Literal settings
+  # Or use the curl-based wrapper (best if Python gets Cloudflare 1010):
+  ./literal-to-storygraph.sh -o storygraph-import.csv
+
+  # Convert a Literal CSV you already have on disk
   python3 literal-to-storygraph.py literal-export.csv -o storygraph-import.csv
 """
 
@@ -24,6 +27,8 @@ import csv
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -35,11 +40,10 @@ from typing import Any
 GRAPHQL_URL = "https://literal.club/graphql/"
 EXPORT_URL = "https://literal.club/api/export/csv"
 
-# Literal sits behind Cloudflare Browser Integrity Check. Python's default
-# User-Agent (Python-urllib/...) triggers HTTP 403 / error 1010 unless we
-# send browser-like headers.
+# Literal sits behind Cloudflare Browser Integrity Check. Python's default TLS
+# fingerprint (urllib) often triggers HTTP 403 / error 1010. curl does not.
 BROWSER_USER_AGENT = (
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 )
 
@@ -63,18 +67,132 @@ def literal_request_headers(
     return headers
 
 
-def format_http_error(exc: urllib.error.HTTPError) -> str:
-    detail = exc.read().decode("utf-8", errors="replace").strip()
-    if exc.code == 403 and "1010" in detail:
+def cloudflare_help(status: int, detail: str) -> str:
+    if status == 403 and "1010" in detail:
         return (
-            f"Literal API HTTP {exc.code}: Cloudflare blocked this request (error 1010). "
-            "Literal rejects non-browser HTTP clients. Update to the latest version of "
-            "this script, or export from Literal in your browser and pass the CSV file "
-            "instead of using --fetch."
+            f"Literal API HTTP {status}: Cloudflare blocked this request (error 1010). "
+            "Try the curl wrapper instead:\n"
+            "  ./scripts/literal-to-storygraph.sh -o storygraph-import.csv\n"
+            "Or re-run with: --http-backend curl\n"
+            "If login is also blocked, log into literal.club in your browser, "
+            "then set LITERAL_TOKEN from a curl login on your machine."
         )
     if detail:
-        return f"Literal API HTTP {exc.code}: {detail}"
-    return f"Literal API HTTP {exc.code}"
+        return f"Literal API HTTP {status}: {detail}"
+    return f"Literal API HTTP {status}"
+
+
+class LiteralHttp:
+    def __init__(self, backend: str = "curl") -> None:
+        self.backend = backend
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: str | None = None,
+        timeout: int = 60,
+    ) -> tuple[int, str]:
+        if self.backend == "curl":
+            return self._request_curl(method, url, headers, body, timeout)
+        if self.backend == "curl_cffi":
+            return self._request_curl_cffi(method, url, headers, body, timeout)
+        return self._request_urllib(method, url, headers, body, timeout)
+
+    @staticmethod
+    def _request_curl(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: str | None,
+        timeout: int,
+    ) -> tuple[int, str]:
+        if not shutil.which("curl"):
+            raise RuntimeError("curl is required but was not found on PATH.")
+
+        cmd = [
+            "curl",
+            "-sS",
+            "-X",
+            method,
+            "-w",
+            "\n__CURL_HTTP_CODE__:%{http_code}",
+            "--max-time",
+            str(timeout),
+            url,
+        ]
+        for key, value in headers.items():
+            cmd.extend(["-H", f"{key}: {value}"])
+        if body is not None:
+            cmd.extend(["--data-binary", body])
+
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"Failed to run curl: {exc}") from exc
+
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(f"curl failed: {detail}")
+
+        output = completed.stdout
+        marker = "\n__CURL_HTTP_CODE__:"
+        if marker not in output:
+            raise RuntimeError(f"Unexpected curl output: {output[:200]}")
+        response_body, _, status_part = output.rpartition(marker)
+        return int(status_part), response_body
+
+    @staticmethod
+    def _request_curl_cffi(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: str | None,
+        timeout: int,
+    ) -> tuple[int, str]:
+        try:
+            from curl_cffi import requests as curl_requests
+        except ImportError as exc:
+            raise RuntimeError(
+                "curl_cffi is not installed. Run: pip install curl_cffi"
+            ) from exc
+
+        response = curl_requests.request(
+            method,
+            url,
+            headers=headers,
+            data=body,
+            impersonate="chrome131",
+            timeout=timeout,
+        )
+        return response.status_code, response.text
+
+    @staticmethod
+    def _request_urllib(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: str | None,
+        timeout: int,
+    ) -> tuple[int, str]:
+        request = urllib.request.Request(
+            url,
+            data=body.encode("utf-8") if body is not None else None,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return response.status, response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(cloudflare_help(exc.code, detail)) from exc
 
 GOODREADS_HEADERS = [
     "Book Id",
@@ -142,32 +260,43 @@ class BookRow:
 
 
 class LiteralClient:
-    def __init__(self, token: str) -> None:
+    def __init__(self, token: str, http: LiteralHttp | None = None) -> None:
         self.token = token
+        self.http = http or LiteralHttp("curl")
 
-    def graphql(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
-        payload = {"query": query}
-        if variables:
-            payload["variables"] = variables
-        request = urllib.request.Request(
-            GRAPHQL_URL,
-            data=json.dumps(payload).encode("utf-8"),
-            headers=literal_request_headers(self.token, json_body=True),
-            method="POST",
+    def _post_json(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        token: str | None = None,
+        timeout: int = 60,
+    ) -> dict[str, Any]:
+        status, raw = self.http.request(
+            "POST",
+            url,
+            literal_request_headers(token or self.token, json_body=True),
+            json.dumps(payload),
+            timeout=timeout,
         )
-        try:
-            with urllib.request.urlopen(request, timeout=60) as response:
-                body = json.loads(response.read().decode("utf-8"))
-        except urllib.error.HTTPError as exc:
-            raise RuntimeError(format_http_error(exc)) from exc
-
+        if status >= 400:
+            raise RuntimeError(cloudflare_help(status, raw))
+        body = json.loads(raw)
         if body.get("errors"):
             messages = "; ".join(err.get("message", str(err)) for err in body["errors"])
             raise RuntimeError(f"Literal API error: {messages}")
+        return body
+
+    def graphql(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = variables
+        body = self._post_json(GRAPHQL_URL, payload)
         return body.get("data") or {}
 
     @staticmethod
-    def login(email: str, password: str) -> tuple[str, str]:
+    def login(email: str, password: str, http: LiteralHttp | None = None) -> tuple[str, str]:
+        client = http or LiteralHttp("curl")
         query = """
         mutation Login($email: String!, $password: String!) {
           login(email: $email, password: $password) {
@@ -177,17 +306,15 @@ class LiteralClient:
         }
         """
         payload = {"query": query, "variables": {"email": email, "password": password}}
-        request = urllib.request.Request(
+        status, raw = client.request(
+            "POST",
             GRAPHQL_URL,
-            data=json.dumps(payload).encode("utf-8"),
-            headers=literal_request_headers(json_body=True),
-            method="POST",
+            literal_request_headers(json_body=True),
+            json.dumps(payload),
         )
-        try:
-            with urllib.request.urlopen(request, timeout=60) as response:
-                body = json.loads(response.read().decode("utf-8"))
-        except urllib.error.HTTPError as exc:
-            raise RuntimeError(format_http_error(exc)) from exc
+        if status >= 400:
+            raise RuntimeError(cloudflare_help(status, raw))
+        body = json.loads(raw)
         if body.get("errors"):
             messages = "; ".join(err.get("message", str(err)) for err in body["errors"])
             raise RuntimeError(f"Login failed: {messages}")
@@ -198,16 +325,15 @@ class LiteralClient:
         return login_data["token"], profile.get("id", "")
 
     def download_literal_csv(self) -> str:
-        request = urllib.request.Request(
+        status, raw = self.http.request(
+            "GET",
             EXPORT_URL,
-            headers=literal_request_headers(self.token),
-            method="GET",
+            literal_request_headers(self.token),
+            timeout=120,
         )
-        try:
-            with urllib.request.urlopen(request, timeout=120) as response:
-                return response.read().decode("utf-8")
-        except urllib.error.HTTPError as exc:
-            raise RuntimeError(format_http_error(exc)) from exc
+        if status >= 400:
+            raise RuntimeError(cloudflare_help(status, raw))
+        return raw
 
 
 def parse_iso_date(value: str | None) -> str:
@@ -521,7 +647,7 @@ def write_goodreads_csv(path: str, rows: list[dict[str, str]]) -> None:
         writer.writerows(rows)
 
 
-def resolve_token(args: argparse.Namespace) -> tuple[str, str]:
+def resolve_token(args: argparse.Namespace, http: LiteralHttp) -> tuple[str, str]:
     token = args.token or os.environ.get("LITERAL_TOKEN", "").strip()
     profile_id = os.environ.get("LITERAL_PROFILE_ID", "").strip()
 
@@ -534,7 +660,7 @@ def resolve_token(args: argparse.Namespace) -> tuple[str, str]:
         raise RuntimeError(
             "Set LITERAL_TOKEN, or LITERAL_EMAIL and LITERAL_PASSWORD, to fetch from Literal."
         )
-    token, profile_id = LiteralClient.login(email, password)
+    token, profile_id = LiteralClient.login(email, password, http=http)
     return token, profile_id
 
 
@@ -567,12 +693,19 @@ def main() -> int:
         "--token",
         help="Literal API token (overrides LITERAL_TOKEN).",
     )
+    parser.add_argument(
+        "--http-backend",
+        choices=("curl", "curl_cffi", "urllib"),
+        default="curl",
+        help="HTTP client for Literal API calls (default: curl, most reliable).",
+    )
     args = parser.parse_args()
 
     try:
         if args.fetch:
-            token, profile_id = resolve_token(args)
-            client = LiteralClient(token)
+            http = LiteralHttp(args.http_backend)
+            token, profile_id = resolve_token(args, http)
+            client = LiteralClient(token, http=http)
             if not profile_id:
                 me = client.graphql("query { me { profile { id handle } } }")
                 profile_id = ((me.get("me") or {}).get("profile") or {}).get("id", "")
@@ -598,7 +731,7 @@ def main() -> int:
 
         rows = to_goodreads_rows(books)
         write_goodreads_csv(args.output, rows)
-    except (RuntimeError, OSError, urllib.error.URLError) as exc:
+    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 

--- a/scripts/literal-to-storygraph.py
+++ b/scripts/literal-to-storygraph.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""
+Export Literal.club library data to a Goodreads-format CSV for The StoryGraph.
+
+StoryGraph only accepts Goodreads-style bulk imports:
+  https://app.thestorygraph.com/import-goodreads
+
+Usage:
+  # Fetch from Literal API and write StoryGraph import CSV
+  LITERAL_EMAIL=you@example.com LITERAL_PASSWORD='...' \\
+    python3 literal-to-storygraph.py --fetch -o storygraph-import.csv
+
+  # Or use an existing token (valid ~6 months)
+  LITERAL_TOKEN='...' python3 literal-to-storygraph.py --fetch -o storygraph-import.csv
+
+  # Convert a CSV you downloaded from Literal settings
+  python3 literal-to-storygraph.py literal-export.csv -o storygraph-import.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+GRAPHQL_URL = "https://literal.club/graphql/"
+EXPORT_URL = "https://literal.club/api/export/csv"
+
+GOODREADS_HEADERS = [
+    "Book Id",
+    "Title",
+    "Author",
+    "Author l-f",
+    "Additional Authors",
+    "ISBN",
+    "ISBN13",
+    "My Rating",
+    "Average Rating",
+    "Publisher",
+    "Binding",
+    "Number of Pages",
+    "Year Published",
+    "Original Publication Year",
+    "Date Read",
+    "Date Added",
+    "Bookshelves",
+    "Bookshelves with positions",
+    "Exclusive Shelf",
+    "My Review",
+    "Spoiler",
+    "Private Notes",
+    "Read Count",
+    "Owned Copies",
+]
+
+STATUS_TO_SHELF = {
+    "FINISHED": "read",
+    "IS_READING": "currently-reading",
+    "WANTS_TO_READ": "to-read",
+    "DROPPED": "did-not-finish",
+    "NONE": "to-read",
+    # Literal CSV / human-readable labels
+    "finished": "read",
+    "reading": "currently-reading",
+    "is_reading": "currently-reading",
+    "currently reading": "currently-reading",
+    "want to read": "to-read",
+    "wants to read": "to-read",
+    "want": "to-read",
+    "dropped": "did-not-finish",
+    "dnf": "did-not-finish",
+    "read": "read",
+    "to-read": "to-read",
+    "currently-reading": "currently-reading",
+    "did-not-finish": "did-not-finish",
+}
+
+
+@dataclass
+class BookRow:
+    book_id: str
+    title: str
+    author: str
+    isbn10: str = ""
+    isbn13: str = ""
+    status: str = "WANTS_TO_READ"
+    date_added: str = ""
+    date_read: str = ""
+    rating: float = 0.0
+    review: str = ""
+    shelves: list[str] = field(default_factory=list)
+
+
+class LiteralClient:
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def graphql(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload = {"query": query}
+        if variables:
+            payload["variables"] = variables
+        request = urllib.request.Request(
+            GRAPHQL_URL,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.token}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Literal API HTTP {exc.code}: {detail}") from exc
+
+        if body.get("errors"):
+            messages = "; ".join(err.get("message", str(err)) for err in body["errors"])
+            raise RuntimeError(f"Literal API error: {messages}")
+        return body.get("data") or {}
+
+    @staticmethod
+    def login(email: str, password: str) -> tuple[str, str]:
+        query = """
+        mutation Login($email: String!, $password: String!) {
+          login(email: $email, password: $password) {
+            token
+            profile { id handle }
+          }
+        }
+        """
+        payload = {"query": query, "variables": {"email": email, "password": password}}
+        request = urllib.request.Request(
+            GRAPHQL_URL,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.loads(response.read().decode("utf-8"))
+        if body.get("errors"):
+            messages = "; ".join(err.get("message", str(err)) for err in body["errors"])
+            raise RuntimeError(f"Login failed: {messages}")
+        login_data = (body.get("data") or {}).get("login")
+        if not login_data or not login_data.get("token"):
+            raise RuntimeError("Login failed: no token returned")
+        profile = login_data.get("profile") or {}
+        return login_data["token"], profile.get("id", "")
+
+    def download_literal_csv(self) -> str:
+        request = urllib.request.Request(
+            EXPORT_URL,
+            headers={"Authorization": f"Bearer {self.token}"},
+            method="GET",
+        )
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return response.read().decode("utf-8")
+
+
+def parse_iso_date(value: str | None) -> str:
+    if not value:
+        return ""
+    value = value.strip()
+    if not value:
+        return ""
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+    ):
+        try:
+            return datetime.strptime(value, fmt).strftime("%Y/%m/%d")
+        except ValueError:
+            continue
+    if "T" in value:
+        return parse_iso_date(value.split("T", 1)[0].replace("-", "/"))
+    return value.replace("-", "/")
+
+
+def author_lf(name: str) -> str:
+    parts = [p for p in name.strip().split() if p]
+    if len(parts) <= 1:
+        return name
+    return f"{parts[-1]}, {' '.join(parts[:-1])}"
+
+
+def slugify_tag(name: str) -> str:
+    cleaned = re.sub(r"[^\w\s-]", "", name.strip().lower())
+    return re.sub(r"[\s_]+", "-", cleaned).strip("-")
+
+
+def normalize_status(raw: str) -> str:
+    key = raw.strip().lower().replace("_", " ")
+    key = re.sub(r"\s+", " ", key)
+    return STATUS_TO_SHELF.get(raw.strip(), STATUS_TO_SHELF.get(key, "to-read"))
+
+
+def read_count_for_shelf(exclusive_shelf: str) -> int:
+    return 1 if exclusive_shelf == "read" else 0
+
+
+def format_rating(value: float | int | str | None) -> str:
+    if value in (None, "", 0, "0", 0.0):
+        return "0"
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "0"
+    if number <= 0:
+        return "0"
+    if number.is_integer():
+        return str(int(number))
+    return str(number)
+
+
+def join_authors(authors: Iterable[str]) -> str:
+    names = [a.strip() for a in authors if a and a.strip()]
+    return ", ".join(names)
+
+
+def fetch_books_from_api(client: LiteralClient, profile_id: str) -> list[BookRow]:
+    reading_states_query = """
+    query MyReadingStates {
+      myReadingStates {
+        id
+        status
+        bookId
+        createdAt
+        book {
+          id
+          title
+          isbn10
+          isbn13
+          authors { name }
+        }
+      }
+    }
+    """
+    export_query = """
+    query MyBooksExport {
+      myBooksExport {
+        id
+        title
+        authors
+        isbn10
+        isbn13
+        shelves
+      }
+    }
+    """
+    reviews_query = """
+    query MyReviews($limit: Int!, $offset: Int!) {
+      myReviews(limit: $limit, offset: $offset) {
+        ... on BookReviewActivity {
+          data {
+            rating
+            text
+            book { id }
+          }
+          object
+        }
+      }
+    }
+    """
+    read_dates_query = """
+    query GetReadDates($bookId: String!, $profileId: String!) {
+      getReadDates(bookId: $bookId, profileId: $profileId) {
+        started
+        finished
+      }
+    }
+    """
+
+    states = client.graphql(reading_states_query).get("myReadingStates") or []
+    export_rows = client.graphql(export_query).get("myBooksExport") or []
+    shelves_by_book: dict[str, list[str]] = {}
+    for item in export_rows:
+        book_id = item.get("id") or ""
+        raw_shelves = item.get("shelves") or []
+        if isinstance(raw_shelves, str):
+            raw_shelves = [s.strip() for s in raw_shelves.split(",") if s.strip()]
+        shelves_by_book[book_id] = [str(s).strip() for s in raw_shelves if str(s).strip()]
+
+    reviews_by_book: dict[str, dict[str, Any]] = {}
+    offset = 0
+    page_size = 100
+    while True:
+        page = client.graphql(reviews_query, {"limit": page_size, "offset": offset}).get("myReviews") or []
+        if not page:
+            break
+        for activity in page:
+            data = activity.get("data") or {}
+            book = data.get("book") or {}
+            book_id = book.get("id") or activity.get("object") or ""
+            if book_id:
+                reviews_by_book[book_id] = data
+        if len(page) < page_size:
+            break
+        offset += page_size
+
+    books: dict[str, BookRow] = {}
+    for state in states:
+        book = state.get("book") or {}
+        book_id = book.get("id") or state.get("bookId") or ""
+        if not book_id:
+            continue
+        authors = [a.get("name", "") for a in book.get("authors") or [] if a.get("name")]
+        if not authors and book_id in {row.get("id") for row in export_rows}:
+            export_match = next((row for row in export_rows if row.get("id") == book_id), None)
+            if export_match and export_match.get("authors"):
+                if isinstance(export_match["authors"], list):
+                    authors = [str(a) for a in export_match["authors"]]
+                else:
+                    authors = [export_match["authors"]]
+
+        row = BookRow(
+            book_id=book_id,
+            title=(book.get("title") or "").strip(),
+            author=join_authors(authors),
+            isbn10=(book.get("isbn10") or "").strip(),
+            isbn13=(book.get("isbn13") or "").strip(),
+            status=(state.get("status") or "WANTS_TO_READ").strip(),
+            date_added=parse_iso_date(state.get("createdAt")),
+            shelves=shelves_by_book.get(book_id, []),
+        )
+
+        review = reviews_by_book.get(book_id)
+        if review:
+            row.rating = float(review.get("rating") or 0)
+            row.review = (review.get("text") or "").strip()
+
+        books[book_id] = row
+
+    for book_id, row in books.items():
+        if row.status not in {"FINISHED", "DROPPED"}:
+            continue
+        dates = client.graphql(
+            read_dates_query,
+            {"bookId": book_id, "profileId": profile_id},
+        ).get("getReadDates") or []
+        if not dates:
+            continue
+        latest = max(
+            dates,
+            key=lambda item: item.get("finished") or item.get("started") or "",
+        )
+        row.date_read = parse_iso_date(latest.get("finished") or latest.get("started"))
+
+    return list(books.values())
+
+
+def pick(row: dict[str, str], *names: str) -> str:
+    lowered = {key.strip().lower(): value for key, value in row.items()}
+    for name in names:
+        value = lowered.get(name.lower())
+        if value is not None and str(value).strip() != "":
+            return str(value).strip()
+    return ""
+
+
+def parse_literal_csv(text: str) -> list[BookRow]:
+    reader = csv.DictReader(text.splitlines())
+    if not reader.fieldnames:
+        raise RuntimeError("Literal CSV appears to have no header row")
+
+    books: list[BookRow] = []
+    for index, row in enumerate(reader, start=2):
+        title = pick(row, "title", "book title", "name")
+        if not title:
+            continue
+
+        author = pick(row, "author", "authors", "author(s)")
+        status = pick(
+            row,
+            "status",
+            "reading status",
+            "readingstate",
+            "reading state",
+            "exclusive shelf",
+            "shelf",
+        )
+        isbn13 = pick(row, "isbn13", "isbn 13", "isbn/uid", "isbn")
+        isbn10 = pick(row, "isbn10", "isbn 10")
+        if len(isbn13) == 10 and not isbn10:
+            isbn10, isbn13 = isbn13, ""
+
+        shelves_raw = pick(row, "shelves", "bookshelves", "tags", "custom shelves")
+        shelves = []
+        if shelves_raw:
+            shelves = [s.strip() for s in re.split(r"[;,|]", shelves_raw) if s.strip()]
+
+        rating_raw = pick(row, "rating", "my rating", "star rating", "score")
+        review = pick(row, "review", "my review", "text")
+        date_added = parse_iso_date(pick(row, "date added", "added", "createdat", "created at"))
+        date_read = parse_iso_date(
+            pick(row, "date read", "finished", "date finished", "last date read", "read date")
+        )
+
+        book_id = pick(row, "id", "book id", "bookid") or f"literal-{index}"
+        books.append(
+            BookRow(
+                book_id=book_id,
+                title=title,
+                author=author,
+                isbn10=isbn10,
+                isbn13=isbn13,
+                status=status or "WANTS_TO_READ",
+                date_added=date_added,
+                date_read=date_read,
+                rating=float(rating_raw) if rating_raw else 0.0,
+                review=review,
+                shelves=shelves,
+            )
+        )
+    return books
+
+
+def to_goodreads_rows(books: Iterable[BookRow]) -> list[dict[str, str]]:
+    output: list[dict[str, str]] = []
+    for book in books:
+        exclusive_shelf = normalize_status(book.status)
+        shelf_tags = [slugify_tag(name) for name in book.shelves if name]
+        shelf_tags = [tag for tag in shelf_tags if tag and tag not in {
+            "read",
+            "to-read",
+            "currently-reading",
+            "did-not-finish",
+        }]
+        bookshelves = ", ".join(dict.fromkeys(shelf_tags))
+        date_added = book.date_added or book.date_read or datetime.now().strftime("%Y/%m/%d")
+
+        output.append(
+            {
+                "Book Id": book.book_id,
+                "Title": book.title,
+                "Author": book.author,
+                "Author l-f": author_lf(book.author) if book.author else "",
+                "Additional Authors": "",
+                "ISBN": book.isbn10,
+                "ISBN13": book.isbn13,
+                "My Rating": format_rating(book.rating),
+                "Average Rating": "",
+                "Publisher": "",
+                "Binding": "",
+                "Number of Pages": "",
+                "Year Published": "",
+                "Original Publication Year": "",
+                "Date Read": book.date_read if exclusive_shelf == "read" else "",
+                "Date Added": date_added,
+                "Bookshelves": bookshelves,
+                "Bookshelves with positions": "",
+                "Exclusive Shelf": exclusive_shelf,
+                "My Review": book.review,
+                "Spoiler": "",
+                "Private Notes": "",
+                "Read Count": str(read_count_for_shelf(exclusive_shelf)),
+                "Owned Copies": "",
+            }
+        )
+    return output
+
+
+def write_goodreads_csv(path: str, rows: list[dict[str, str]]) -> None:
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=GOODREADS_HEADERS, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def resolve_token(args: argparse.Namespace) -> tuple[str, str]:
+    token = args.token or os.environ.get("LITERAL_TOKEN", "").strip()
+    profile_id = os.environ.get("LITERAL_PROFILE_ID", "").strip()
+
+    if token:
+        return token, profile_id
+
+    email = os.environ.get("LITERAL_EMAIL", "").strip()
+    password = os.environ.get("LITERAL_PASSWORD", "").strip()
+    if not email or not password:
+        raise RuntimeError(
+            "Set LITERAL_TOKEN, or LITERAL_EMAIL and LITERAL_PASSWORD, to fetch from Literal."
+        )
+    token, profile_id = LiteralClient.login(email, password)
+    return token, profile_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert Literal.club library data to a StoryGraph-compatible Goodreads CSV."
+    )
+    parser.add_argument(
+        "input_csv",
+        nargs="?",
+        help="Optional Literal CSV export from Settings. Omit when using --fetch.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="storygraph-import.csv",
+        help="Output CSV path (default: storygraph-import.csv)",
+    )
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help="Fetch library data from Literal via GraphQL instead of converting a CSV file.",
+    )
+    parser.add_argument(
+        "--download-literal-csv",
+        action="store_true",
+        help="When used with --fetch, also save Literal's native CSV export alongside the StoryGraph file.",
+    )
+    parser.add_argument(
+        "--token",
+        help="Literal API token (overrides LITERAL_TOKEN).",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.fetch:
+            token, profile_id = resolve_token(args)
+            client = LiteralClient(token)
+            if not profile_id:
+                me = client.graphql("query { me { profile { id handle } } }")
+                profile_id = ((me.get("me") or {}).get("profile") or {}).get("id", "")
+            if not profile_id:
+                raise RuntimeError("Could not determine your Literal profile id.")
+
+            if args.download_literal_csv:
+                literal_csv_path = os.path.splitext(args.output)[0] + ".literal.csv"
+                literal_csv = client.download_literal_csv()
+                with open(literal_csv_path, "w", encoding="utf-8", newline="") as handle:
+                    handle.write(literal_csv)
+                print(f"Saved Literal export to {literal_csv_path}", file=sys.stderr)
+
+            books = fetch_books_from_api(client, profile_id)
+        else:
+            if not args.input_csv:
+                parser.error("Provide a Literal CSV file, or use --fetch.")
+            with open(args.input_csv, encoding="utf-8-sig", newline="") as handle:
+                books = parse_literal_csv(handle.read())
+
+        if not books:
+            raise RuntimeError("No books found to export.")
+
+        rows = to_goodreads_rows(books)
+        write_goodreads_csv(args.output, rows)
+    except (RuntimeError, OSError, urllib.error.URLError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Wrote {len(rows)} books to {args.output}", file=sys.stderr)
+    print(
+        "Import this file at https://app.thestorygraph.com/import-goodreads",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/literal-to-storygraph.py
+++ b/scripts/literal-to-storygraph.py
@@ -35,6 +35,47 @@ from typing import Any
 GRAPHQL_URL = "https://literal.club/graphql/"
 EXPORT_URL = "https://literal.club/api/export/csv"
 
+# Literal sits behind Cloudflare Browser Integrity Check. Python's default
+# User-Agent (Python-urllib/...) triggers HTTP 403 / error 1010 unless we
+# send browser-like headers.
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+
+def literal_request_headers(
+    token: str | None = None,
+    *,
+    json_body: bool = False,
+) -> dict[str, str]:
+    headers = {
+        "User-Agent": BROWSER_USER_AGENT,
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Origin": "https://literal.club",
+        "Referer": "https://literal.club/",
+    }
+    if json_body:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def format_http_error(exc: urllib.error.HTTPError) -> str:
+    detail = exc.read().decode("utf-8", errors="replace").strip()
+    if exc.code == 403 and "1010" in detail:
+        return (
+            f"Literal API HTTP {exc.code}: Cloudflare blocked this request (error 1010). "
+            "Literal rejects non-browser HTTP clients. Update to the latest version of "
+            "this script, or export from Literal in your browser and pass the CSV file "
+            "instead of using --fetch."
+        )
+    if detail:
+        return f"Literal API HTTP {exc.code}: {detail}"
+    return f"Literal API HTTP {exc.code}"
+
 GOODREADS_HEADERS = [
     "Book Id",
     "Title",
@@ -111,18 +152,14 @@ class LiteralClient:
         request = urllib.request.Request(
             GRAPHQL_URL,
             data=json.dumps(payload).encode("utf-8"),
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.token}",
-            },
+            headers=literal_request_headers(self.token, json_body=True),
             method="POST",
         )
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
                 body = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"Literal API HTTP {exc.code}: {detail}") from exc
+            raise RuntimeError(format_http_error(exc)) from exc
 
         if body.get("errors"):
             messages = "; ".join(err.get("message", str(err)) for err in body["errors"])
@@ -143,11 +180,14 @@ class LiteralClient:
         request = urllib.request.Request(
             GRAPHQL_URL,
             data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
+            headers=literal_request_headers(json_body=True),
             method="POST",
         )
-        with urllib.request.urlopen(request, timeout=60) as response:
-            body = json.loads(response.read().decode("utf-8"))
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(format_http_error(exc)) from exc
         if body.get("errors"):
             messages = "; ".join(err.get("message", str(err)) for err in body["errors"])
             raise RuntimeError(f"Login failed: {messages}")
@@ -160,11 +200,14 @@ class LiteralClient:
     def download_literal_csv(self) -> str:
         request = urllib.request.Request(
             EXPORT_URL,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers=literal_request_headers(self.token),
             method="GET",
         )
-        with urllib.request.urlopen(request, timeout=120) as response:
-            return response.read().decode("utf-8")
+        try:
+            with urllib.request.urlopen(request, timeout=120) as response:
+                return response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(format_http_error(exc)) from exc
 
 
 def parse_iso_date(value: str | None) -> str:

--- a/scripts/literal-to-storygraph.sh
+++ b/scripts/literal-to-storygraph.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Export Literal.club → StoryGraph import CSV using curl for all API calls.
+# Use this if the Python script hits Cloudflare error 1010.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT="storygraph-import.csv"
+
+usage() {
+  cat <<'EOF'
+Usage: literal-to-storygraph.sh [options]
+
+Fetch your Literal library and write a StoryGraph-compatible CSV.
+
+Environment:
+  LITERAL_TOKEN          Use an existing API token (skips login)
+  LITERAL_EMAIL          Literal account email (if no token)
+  LITERAL_PASSWORD       Literal account password (if no token)
+
+Options:
+  -o, --output FILE      Output CSV path (default: storygraph-import.csv)
+  -h, --help             Show this help
+
+Examples:
+  LITERAL_EMAIL=you@example.com LITERAL_PASSWORD='secret' \
+    ./literal-to-storygraph.sh
+
+  LITERAL_TOKEN='eyJ...' ./literal-to-storygraph.sh -o books.csv
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+GRAPHQL='https://literal.club/graphql/'
+
+literal_post() {
+  local payload="$1"
+  local token="${2:-}"
+  local args=(
+    -sS
+    -X POST
+    "$GRAPHQL"
+    -H "Content-Type: application/json"
+    -H "User-Agent: $UA"
+    -H "Accept: application/json, text/plain, */*"
+    -H "Origin: https://literal.club"
+    -H "Referer: https://literal.club/"
+    --data-binary "$payload"
+  )
+  if [[ -n "$token" ]]; then
+    args+=(-H "Authorization: Bearer $token")
+  fi
+  curl "${args[@]}"
+}
+
+if [[ -z "${LITERAL_TOKEN:-}" ]]; then
+  if [[ -z "${LITERAL_EMAIL:-}" || -z "${LITERAL_PASSWORD:-}" ]]; then
+    echo "Set LITERAL_TOKEN, or LITERAL_EMAIL and LITERAL_PASSWORD." >&2
+    exit 1
+  fi
+
+  login_payload=$(jq -n \
+    --arg email "$LITERAL_EMAIL" \
+    --arg password "$LITERAL_PASSWORD" \
+    '{query:"mutation Login($email: String!, $password: String!) { login(email: $email, password: $password) { token profile { id handle } } }", variables:{email:$email, password:$password}}')
+
+  login_response=$(literal_post "$login_payload")
+  if echo "$login_response" | jq -e '.errors' >/dev/null 2>&1; then
+    echo "Login failed: $(echo "$login_response" | jq -r '.errors[0].message')" >&2
+    exit 1
+  fi
+
+  export LITERAL_TOKEN
+  LITERAL_TOKEN=$(echo "$login_response" | jq -r '.data.login.token')
+  export LITERAL_PROFILE_ID
+  LITERAL_PROFILE_ID=$(echo "$login_response" | jq -r '.data.login.profile.id // empty')
+
+  if [[ -z "$LITERAL_TOKEN" || "$LITERAL_TOKEN" == "null" ]]; then
+    echo "Login failed: no token returned." >&2
+    exit 1
+  fi
+  echo "Logged in to Literal." >&2
+fi
+
+exec python3 "$SCRIPT_DIR/literal-to-storygraph.py" \
+  --fetch \
+  --http-backend curl \
+  --token "$LITERAL_TOKEN" \
+  -o "$OUTPUT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `scripts/literal-to-storygraph.py`, a stdlib-only CLI tool for migrating a Literal.club library to The StoryGraph.

## Usage

```bash
# Fetch from Literal API
LITERAL_EMAIL='you@example.com' LITERAL_PASSWORD='...' \
  python3 scripts/literal-to-storygraph.py --fetch -o storygraph-import.csv

# Or convert an existing Literal CSV export
python3 scripts/literal-to-storygraph.py literal-export.csv -o storygraph-import.csv
```

Then upload the output CSV at https://app.thestorygraph.com/import-goodreads.

## What it does

- Authenticates with Literal's GraphQL API (token or email/password)
- Fetches reading states, shelves, ratings, reviews, and read dates
- Writes a Goodreads-format CSV that StoryGraph accepts for bulk import
- Optionally saves Literal's native CSV export via `--download-literal-csv`

## Notes

StoryGraph has no CLI import API — the final upload step is still done in the browser.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e216ef2-2e05-4760-a4ff-2d85b7be51a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e216ef2-2e05-4760-a4ff-2d85b7be51a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

